### PR TITLE
Remove preferences for loop statements

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -13,9 +13,6 @@ JavaScript CodeStyle
   - [Conditional Statements](#conditional-statements)
     - [if](#if)
     - [switch](#switch)
-  - [Loops](#loops)
-    - [for](#for)
-    - [for (var i in obj)](#for-var-i-in-obj)
   - [Operators](#operators)
     - ['with' operator](#with-operator)
     - [Comparison Operators](#comparison-operators)
@@ -313,25 +310,6 @@ switch (value) {
         // ...
         // no break keyword on the last case
 }
-```
-
-##Loops
-###for
-If possible, [Array.prototype.forEach](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) should be used instead of a `for` loop.
-
-```javascript
-[1, 2, 3].forEach(function (value) {
-    console.log(value);
-});
-```
-Performance-critical parts of the code can use a `for` statement.
-
-###for (var i in obj)
-If possible, [Object.keys](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) should be used instead of a `for-in` construction.
-```javascript
-Object.keys(obj).forEach(function (key) {
-    console.log(key);
-});
 ```
 
 ##Operators

--- a/javascript.ru.md
+++ b/javascript.ru.md
@@ -13,9 +13,6 @@ JavaScript CodeStyle
   - [Условные инструкции](#8)
     - [if](#8-1)
     - [switch](#8-2)
-  - [Циклы](#9)
-    - [for](#9-1)
-    - [for (var i in obj)](#9-2)
   - [Операторы](#10)
     - [with](#10-1)
     - [Оператор равенства](#10-2)
@@ -312,27 +309,6 @@ switch (value) {
         // ...
         // no break keyword on the last case
 }
-```
-
-##<a name="9"></a>Циклы
-###<a name="9-1"></a>for
-По возможности вместо `for` используется [Array.prototype.forEach](https://developer.mozilla.org/ru/docs/JavaScript/Reference/Global_Objects/Array/forEach):
-
-```javascript
-[1, 2, 3].forEach(function (value) {
-    console.log(value);
-});
-```
-
-Код с использованием `forEach` проще читать (легче абстрагироваться от того, что происходит в каждой итерации). Где
-критична скорость используется обычный `for`.
-
-###<a name="9-2"></a>for (var i in obj)
-По возможности вместо `for-in` используется [Object.keys](https://developer.mozilla.org/ru/docs/JavaScript/Reference/Global_Objects/Object/keys):
-```javascript
-Object.keys(obj).forEach(function (key) {
-    console.log(key);
-});
 ```
 
 ##<a name="10"></a>Операторы


### PR DESCRIPTION
I have removed preferences on loop statements due to its weak relevance to actual style of the code. See https://github.com/yandex/codestyle/issues/22#issuecomment-68100302.