### PR TITLE
eslint-config: support eslint 2.x

### DIFF
--- a/packages/eslint-config-loris/es5.js
+++ b/packages/eslint-config-loris/es5.js
@@ -31,6 +31,9 @@ module.exports = {
         'radix': 2,
         'yoda': [2, 'never'],
 
+        // http://eslint.org/docs/rules/#strict-mode
+        'strict': [2, 'safe'],
+
         // http://eslint.org/docs/rules/#variables
         'no-delete-var': 2,
         'no-undef': 2,

--- a/packages/eslint-config-loris/es6.js
+++ b/packages/eslint-config-loris/es6.js
@@ -9,9 +9,6 @@ module.exports = {
         // http://eslint.org/docs/rules/#best-practices
         'no-loop-func': 0, // This is not a problem with `let` declarations.
 
-        // http://eslint.org/docs/rules/#strict-mode
-        'strict': [2, 'global'],
-
         // http://eslint.org/docs/rules/#ecmascript-6
         'arrow-parens': [2, 'always'],
         'arrow-spacing': [2, {before: true, after: true}],

--- a/packages/eslint-config-loris/package.json
+++ b/packages/eslint-config-loris/package.json
@@ -16,7 +16,7 @@
     "Alexander Tarmolov <tarmolov@gmail.com>"
   ],
   "peerDependencies": {
-    "eslint": ">=1.10.3 <2"
+    "eslint": "2.x"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Migration guide: http://eslint.org/docs/user-guide/migrating-to-2.0.0

Changes:
1. Enable `strict` rule in `es5.js` config too.
2. Change `strict` rule value to [safe](http://eslint.org/docs/rules/strict#safe-default).