### PR TITLE
"disallowSpaceBeforePostfixUnaryOperators": true

### DIFF
--- a/packages/jscs-preset-loris/preset.json
+++ b/packages/jscs-preset-loris/preset.json
@@ -25,10 +25,7 @@
     ],
 
     "disallowSpaceAfterPrefixUnaryOperators": true,
-    "disallowSpaceBeforePostfixUnaryOperators": [
-        "++",
-        "--"
-    ],
+    "disallowSpaceBeforePostfixUnaryOperators": true,
     "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceAfterBinaryOperators": true,
 


### PR DESCRIPTION
This operands are default ones for this rule:
https://github.com/jscs-dev/node-jscs/blob/master/lib/rules/disallow-space-before-postfix-unary-operators.js#L29
https://github.com/jscs-dev/node-jscs/blob/master/lib/utils.js#L186