### PR TITLE
Rewrite old rule for spaces around comma

### DIFF
--- a/packages/jscs-preset-loris/preset.json
+++ b/packages/jscs-preset-loris/preset.json
@@ -60,9 +60,8 @@
         "beforeAlternate": true
     },
 
-    "disallowSpaceBeforeBinaryOperators": [
-        ","
-    ],
+    "disallowSpaceBeforeComma": true,
+    "requireSpaceAfterComma": true,
     "requireCommaBeforeLineBreak": true,
 
     "validateQuoteMarks": "'",


### PR DESCRIPTION
Comma is no longer considered a binary operator [since 2.0.0](http://jscs.info/changelog#version-2-0-0-https-github-comjscs-devnode-jscscomparev1-13-1-v2-0-0):
> Utils: remove comma from list of binary operators (Oleg Gaidarenko)
