### PR TITLE
eslint-config: Improve "no-multiple-empty-lines" rule

### DIFF
--- a/packages/eslint-config-loris/es5.js
+++ b/packages/eslint-config-loris/es5.js
@@ -98,7 +98,7 @@ module.exports = {
         'new-cap': [2, {capIsNew: false}],
         'new-parens': 2,
         'no-mixed-spaces-and-tabs': 2,
-        'no-multiple-empty-lines': 2,
+        'no-multiple-empty-lines': [2, {max: 1, maxEOF: 0}],
         'no-spaced-func': 2,
         'no-trailing-spaces': 2,
         'no-whitespace-before-property': 2,


### PR DESCRIPTION
**Current behavior:**

* `eslint` allows 2 consecutive blank lines
* `eslint` allows 2 consecutive blank lines at the end of file

**New behavior:**

* `eslint` allows **only** 1 blank line
* `eslint` doesn't allow blank line at the end of file

For more information about options of rule see http://eslint.org/docs/rules/no-multiple-empty-lines#options