### PR TITLE
eslint-config: Add 'id-match' rule

### DIFF
--- a/packages/eslint-config-loris/es5.js
+++ b/packages/eslint-config-loris/es5.js
@@ -90,6 +90,7 @@ module.exports = {
         'computed-property-spacing': [2, 'never'],
         'consistent-this': [2, '_this'],
         'eol-last': 2,
+        // Non-ASCII characters are not allowed in identifiers for variables.
         'id-match': [2, '^[a-zA-Z0-9_\$]*$', {'properties': true}],
         'indent': [2, 4, {SwitchCase: 1}],
         'key-spacing': [2, {beforeColon: false, afterColon: true}],

--- a/packages/eslint-config-loris/es5.js
+++ b/packages/eslint-config-loris/es5.js
@@ -91,7 +91,7 @@ module.exports = {
         'consistent-this': [2, '_this'],
         'eol-last': 2,
         // Non-ASCII characters are not allowed in identifiers for variables.
-        'id-match': [2, '^[a-zA-Z0-9_\$]*$', {'properties': true}],
+        'id-match': [2, '^[a-zA-Z0-9_$]*$', {'properties': true}],
         'indent': [2, 4, {SwitchCase: 1}],
         'key-spacing': [2, {beforeColon: false, afterColon: true}],
         'keyword-spacing': [2, {before: true, after: true}],

--- a/packages/eslint-config-loris/es5.js
+++ b/packages/eslint-config-loris/es5.js
@@ -90,6 +90,7 @@ module.exports = {
         'computed-property-spacing': [2, 'never'],
         'consistent-this': [2, '_this'],
         'eol-last': 2,
+        'id-match': [2, '^[a-zA-Z0-9_\$]*$', {'properties': true}],
         'indent': [2, 4, {SwitchCase: 1}],
         'key-spacing': [2, {beforeColon: false, afterColon: true}],
         'keyword-spacing': [2, {before: true, after: true}],


### PR DESCRIPTION
Ref: eslint/eslint#6341

tl;dr Non-ASCII characters are not allowed in identifiers for variables.