### PR TITLE
es6: default parameters

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -49,6 +49,7 @@ JavaScript Code Style
   - [Classes](#classes-1)
   - [Arrow functions](#arrow-functions)
   - [Template strings](#template-strings)
+  - [Default parameters](#default-parameters)
   - [Generators](#generators)
 - [Node.js](#nodejs)
   - [Importing modules](#importing-modules)
@@ -1109,6 +1110,24 @@ This section describes code style for [ECMAScript 2015 Language Specification](h
 
   ```js
   `Hello ${ name }`
+  ```
+
+[&#8593; back to TOC](#table-of-contents)
+
+### Default parameters
+
+* Spaces around the `=` sign should be used:
+
+  **Good:**
+
+  ```js
+  function project(point, zoom = 23) {}
+  ```
+
+  **Bad:**
+
+  ```js
+  function project(point, zoom=23) {}
   ```
 
 [&#8593; back to TOC](#table-of-contents)


### PR DESCRIPTION
* Additional eslint configuration isn't needed, because [space-infix-ops](http://eslint.org/docs/rules/space-infix-ops) already covers this case.
* There is another point of view from PEP8 http://stackoverflow.com/questions/8853063/pep-8-why-no-spaces-around-in-keyword-argument-or-a-default-parameter-value