### PR TITLE
Add style for computed property names

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -187,6 +187,20 @@ while (items.length) {
   };
   ```
 
+* Spaces inside computed property brackets should not be used:
+
+  **Good:**
+
+  ```js
+  var value = obj[key];
+  ```
+
+  **Bad:**
+
+  ```js
+  var value = obj[ key ];
+  ```
+
 [&#8593; back to TOC](#table-of-contents)
 
 ### Arrays

--- a/packages/eslint-config-loris/es6.js
+++ b/packages/eslint-config-loris/es6.js
@@ -17,6 +17,7 @@ module.exports = {
         'no-const-assign': 2,
         'no-dupe-class-members': 2,
         'no-this-before-super': 2,
+        'no-useless-computed-key': 2,
         'no-var': 2,
         'prefer-arrow-callback': 2,
         'prefer-const': 2,


### PR DESCRIPTION
* Describe style for computed property names. This style is checked using [computed-property-spacing](http://eslint.org/docs/rules/computed-property-spacing)
  eslint rule.
* Add [no-useless-computed-key](http://eslint.org/docs/rules/no-useless-computed-key)
  eslint rule to `es6` config.