### PR TITLE
Disallow usage constructors as factory functions

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -823,6 +823,26 @@ var lazyCompute = (function () {
   });
   ```
 
+* Constructor should not be used as factory function:
+
+  > Explanation:
+  > * It makes code explicit.
+  > * It simplifies migration to [ES6 classes](#classes-1), because class constructors cannot be
+  >   invoked without `new`.
+
+  **Bad:**
+
+  ```js
+  function Foo(bar) {
+      if (!(this instanceof Foo)) {
+          return new Foo(bar);
+      }
+      // ...
+  }
+
+  var foo = Foo();
+  ```
+
 [&#8593; back to TOC](#table-of-contents)
 
 ## Enums

--- a/javascript.md
+++ b/javascript.md
@@ -823,7 +823,7 @@ var lazyCompute = (function () {
   });
   ```
 
-* Constructor should not be used as factory function:
+* Constructor should not be used as a factory function:
 
   > Explanation:
   > * It makes code explicit.


### PR DESCRIPTION
I often see this pattern

```js
function Foo(bar) {
   if (!(this instanceof Foo)) {
       return new Foo(bar);
   }
   // ...
}
```
It allows to create new instance without new:

```js
var foo = Foo(); // same as var foo = new Foo();
```

In my opinion it makes code unclear: if you need factory function - just make factory function, don't use constructor for this. Moreover, in `ES6` `TypeError` will be thrown if try to call constructor without `new`.

So, I suggest to prohibit this pattern.
