### PR TITLE
Update eslint rules (fixes #67)

### DIFF
--- a/packages/eslint-config-loris/es5.js
+++ b/packages/eslint-config-loris/es5.js
@@ -33,7 +33,6 @@ module.exports = {
         'no-alert': 2,
         'no-caller': 2,
         'no-case-declarations': 2,
-        'no-empty-pattern': 2,
         'no-eq-null': 2,
         'no-eval': 2,
         'no-extend-native': 2,
@@ -102,6 +101,7 @@ module.exports = {
         'no-mixed-spaces-and-tabs': 2,
         'no-multiple-empty-lines': [2, {max: 1, maxEOF: 0}],
         'no-spaced-func': 2,
+        'no-tabs': 2,
         'no-trailing-spaces': 2,
         'no-whitespace-before-property': 2,
         'object-curly-spacing': [2, 'never'],
@@ -115,6 +115,7 @@ module.exports = {
         'space-before-function-paren': [2, {anonymous: 'always', named: 'never'}],
         'space-in-parens': [2, 'never'],
         'space-infix-ops': 2,
-        'space-unary-ops': [2, {words: true, nonwords: false}]
+        'space-unary-ops': [2, {words: true, nonwords: false}],
+        'unicode-bom': 2
     }
 };

--- a/packages/eslint-config-loris/es6.js
+++ b/packages/eslint-config-loris/es6.js
@@ -8,6 +8,7 @@ module.exports = {
     rules: {
         // http://eslint.org/docs/rules/#best-practices
         'class-methods-use-this': 2,
+        'no-empty-pattern': 2,
         'no-loop-func': 0, // This is not a problem with `let` declarations.
 
         // http://eslint.org/docs/rules/#ecmascript-6
@@ -17,8 +18,11 @@ module.exports = {
         'no-class-assign': 2,
         'no-const-assign': 2,
         'no-dupe-class-members': 2,
+        'no-new-symbol': 2,
         'no-this-before-super': 2,
         'no-useless-computed-key': 2,
+        'no-useless-constructor': 2,
+        'no-useless-rename': 2,
         'no-var': 2,
         'prefer-arrow-callback': 2,
         'prefer-const': 2,


### PR DESCRIPTION
## New rules
### es5
* [unicode-bom](http://eslint.org/docs/rules/unicode-bom)
* [no-tabs](http://eslint.org/docs/rules/no-tabs)

### es6
* [no-useless-constructor](http://eslint.org/docs/rules/no-useless-constructor)
* [no-useless-rename](http://eslint.org/docs/rules/no-useless-rename)
* [no-new-symbol](http://eslint.org/docs/rules/no-new-symbol)

## Other
* [no-empty-pattern](http://eslint.org/docs/rules/no-empty-pattern) is moved from `es5` to `es6`.