### PR TITLE
eslint-config: allow named functions in prefer-callback rule

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -1088,6 +1088,11 @@ This section describes code style for [ECMAScript 2015 Language Specification](h
   [1, 2, 3].map(function (x) {
       // ...
   }, someObj);
+
+  // Use `function` here, because specify name.
+  decorate(function createSomething() {
+      // ...
+  });
   ```
 
 * Always add parentheses around arrow function parameters:

--- a/packages/eslint-config-loris/es6.js
+++ b/packages/eslint-config-loris/es6.js
@@ -23,7 +23,7 @@ module.exports = {
         'no-useless-constructor': 'error',
         'no-useless-rename': 'error',
         'no-var': 'error',
-        'prefer-arrow-callback': 'error',
+        'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
         'prefer-const': 'error',
         'prefer-rest-params': 'error',
         'prefer-spread': 'error',


### PR DESCRIPTION
Add `allowNamedFunctions` option to `prefer-callback` rule.
Documentation: http://eslint.org/docs/rules/prefer-arrow-callback#allownamedfunctions

Named function expression is useful for debugging, because in stack
trace function has name.