### PR TITLE
eslint: add semi-style, switch-colon-spacing rules

### DIFF
--- a/packages/eslint-config-loris/es5.js
+++ b/packages/eslint-config-loris/es5.js
@@ -114,6 +114,7 @@ module.exports = {
         'quote-props': ['error', 'as-needed'],
         'quotes': ['error', 'single'],
         'semi': ['error', 'always'],
+        'semi-style': ['error', 'last'],
         'space-before-blocks': ['error', 'always'],
         'space-before-function-paren': ['error', {
             anonymous: 'always',
@@ -123,6 +124,7 @@ module.exports = {
         'space-in-parens': ['error', 'never'],
         'space-infix-ops': 'error',
         'space-unary-ops': ['error', {words: true, nonwords: false}],
+        'switch-colon-spacing': ['error', {after: true, before: false}],
         'unicode-bom': 'error'
     }
 };


### PR DESCRIPTION
Add new rules to eslint `loris/es5` config:

* [semi-style](https://eslint.org/docs/4.0.0/rules/semi-style)
* [switch-colon-spacing](https://eslint.org/docs/rules/switch-colon-spacing)

Both rules are available since `eslint v4.0.0`.