### PR TITLE
tslint-config: add 'check-type-operator' to 'whitespace' rule

### DIFF
--- a/packages/tslint-config-loris/index.js
+++ b/packages/tslint-config-loris/index.js
@@ -94,7 +94,8 @@ module.exports = {
             'check-decl',
             'check-operator',
             'check-separator',
-            'check-type'
+            'check-type',
+            'check-type-operator'
         ],
 
         // https://github.com/buzinas/tslint-eslint-rules#ecmascript-6

--- a/typescript.md
+++ b/typescript.md
@@ -128,6 +128,20 @@ from JS).
   }
   ```
 
+* There should be one whitespace before and after the type operator:
+
+  **Good:**
+
+  ```ts
+  let foo: string | number;
+  ```
+
+  **Bad:**
+
+  ```ts
+  let foo: string|number;
+  ```
+
 [&#8593; back to TOC](#table-of-contents)
 
 ## Type assertions


### PR DESCRIPTION
Bad:

```ts
type A = string|number;
type A = string| number;
type A = string |number;
```

Good:

```ts
type A = string | number;
```