### PR TITLE
DON'T use async when it has no useful effect

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -1404,7 +1404,6 @@ the asterisk should be sticked to the `yield` keyword:
   }
   ```
 
-
   **Bad:**
 
   ```js

--- a/javascript.md
+++ b/javascript.md
@@ -1415,7 +1415,7 @@ the asterisk should be sticked to the `yield` keyword:
   Cases where async is useful include:
   * You are using await. (This is the obvious one.)
   * You are returning an error asynchronously.
-  * You are returning a value and you want it implicitly wrapped in a future.
+  * You are returning a value and you want it implicitly wrapped in a promise.
 
    **Good:**
 

--- a/javascript.md
+++ b/javascript.md
@@ -1392,8 +1392,8 @@ the asterisk should be sticked to the `yield` keyword:
 
 * Don't use `async` when it has no useful effect.
 
-  It’s easy to get in the habit of using async on any function that does anything related to
-  asynchrony. But in some cases, it’s extraneous. If you can omit the async without changing the
+  It's easy to get in the habit of using async on any function that does anything related to
+  asynchrony. But in some cases, it's extraneous. If you can omit the async without changing the
   behavior of the function, do so.
 
   **Good:**

--- a/javascript.md
+++ b/javascript.md
@@ -1390,6 +1390,44 @@ the asterisk should be sticked to the `yield` keyword:
   }
   ```
 
+* Don't use `async` when it has no useful effect.
+
+  It’s easy to get in the habit of using async on any function that does anything related to
+  asynchrony. But in some cases, it’s extraneous. If you can omit the async without changing the
+  behavior of the function, do so.
+
+  **Good:**
+
+  ```js
+  function afterTwoThings(first, second) {
+      return Promise.all([first, second]);
+  }
+  ```
+
+
+  **Bad:**
+
+  ```js
+  async function afterTwoThings(first, second) {
+      return Promise.all([first, second]);
+  }
+  ```
+
+  Cases where async is useful include:
+  * You are using await. (This is the obvious one.)
+  * You are returning an error asynchronously.
+  * You are returning a value and you want it implicitly wrapped in a future.
+
+   **Good:**
+
+   ```js
+   async function asyncError() {
+      throw new Error('Error!');
+   }
+
+   const asyncValue = async () => 'value';
+   ```
+
 [&#8593; back to TOC](#table-of-contents)
 
 ## Node.js

--- a/javascript.md
+++ b/javascript.md
@@ -1417,15 +1417,15 @@ the asterisk should be sticked to the `yield` keyword:
   * You are returning an error asynchronously.
   * You are returning a value and you want it implicitly wrapped in a promise.
 
-   **Good:**
+  **Good:**
 
-   ```js
-   async function asyncError() {
+  ```js
+  async function asyncError() {
       throw new Error('Error!');
-   }
+  }
 
-   const asyncValue = async () => 'value';
-   ```
+  const asyncValue = async () => 'value';
+  ```
 
 [&#8593; back to TOC](#table-of-contents)
 


### PR DESCRIPTION
This rule based on Dart's rule
https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-async-when-it-has-no-useful-effect

Fixes #108 