### PR TITLE
Include tslint-eslint-rules as normal dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/packages/tslint-config-loris/README.md
+++ b/packages/tslint-config-loris/README.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ```
-npm install --save-dev tslint tslint-eslint-rules tslint-config-loris
+npm install --save-dev tslint tslint-config-loris
 ```
 
 ## Usage

--- a/packages/tslint-config-loris/package.json
+++ b/packages/tslint-config-loris/package.json
@@ -15,8 +15,10 @@
     "Konstantin Ikonnikov <ikokostya@gmail.com>"
   ],
   "peerDependencies": {
-    "tslint": "^5.8.0",
-    "tslint-eslint-rules": ">=4.1.1 <6"
+    "tslint": "^5.8.0"
+  },
+  "dependencies": {
+    "tslint-eslint-rules": "^5.1.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
There are no objectives to include `tslint-eslint-rules` as peer
dependency, because it can be updated after reinstall `tslint-config-loris`
package.