### PR TITLE
tslint-config: Forbid public modifier for members

### DIFF
--- a/packages/tslint-config-loris/index.js
+++ b/packages/tslint-config-loris/index.js
@@ -17,7 +17,7 @@ module.exports = {
         ],
         'array-type': [true, 'array'],
         'class-name': true,
-        // Forbid public modifier for members, because this is the default in TypeScript.
+        // Forbid public modifier for members.
         'member-access': [true, 'no-public'],
 
         // https://github.com/buzinas/tslint-eslint-rules#possible-errors

--- a/packages/tslint-config-loris/index.js
+++ b/packages/tslint-config-loris/index.js
@@ -17,6 +17,8 @@ module.exports = {
         ],
         'array-type': [true, 'array'],
         'class-name': true,
+        // Forbid public modifier for members, because this is the default in TypeScript.
+        'member-access': [true, 'no-public'],
 
         // https://github.com/buzinas/tslint-eslint-rules#possible-errors
         'trailing-comma': [true, {multiline: 'never', singleline: 'never'}],


### PR DESCRIPTION
Forbid `public` modifier usage in `tslint` according to  current style guide rule: https://github.com/ymaps/codestyle/blob/master/typescript.md#classes

Documentation links:
* [`member-access`](https://palantir.github.io/tslint/rules/member-access/) rule (available in `tslint >= 5.0.0` https://github.com/palantir/tslint/blob/master/CHANGELOG.md#v500)