### PR TITLE
tslint-config: Disallow angle bracker type assertions

### DIFF
--- a/packages/tslint-config-loris/index.js
+++ b/packages/tslint-config-loris/index.js
@@ -19,7 +19,7 @@ module.exports = {
         'class-name': true,
         // Forbid public modifier for members.
         'member-access': [true, 'no-public'],
-        "no-angle-bracket-type-assertion": true,
+        'no-angle-bracket-type-assertion': true,
 
         // https://github.com/buzinas/tslint-eslint-rules#possible-errors
         'trailing-comma': [true, {multiline: 'never', singleline: 'never'}],

--- a/packages/tslint-config-loris/index.js
+++ b/packages/tslint-config-loris/index.js
@@ -19,6 +19,7 @@ module.exports = {
         'class-name': true,
         // Forbid public modifier for members.
         'member-access': [true, 'no-public'],
+        "no-angle-bracket-type-assertion": true,
 
         // https://github.com/buzinas/tslint-eslint-rules#possible-errors
         'trailing-comma': [true, {multiline: 'never', singleline: 'never'}],

--- a/typescript.md
+++ b/typescript.md
@@ -159,18 +159,20 @@ add the following options:
 
 ## Type assertions
 
-* If you don't use `JSX`, use "angle-bracket" syntax:
+* Use `as Type` for type assertions:
+
+  > Explanation: Use one style for `JSX` and not.
 
   **Good:**
 
   ```ts
-  (<string>someValue).length;
+  (someValue as string).length;
   ```
 
   **Bad:**
 
   ```ts
-  (someValue as string).length;
+  (<string>someValue).length;
   ```
 
 ## Arrays


### PR DESCRIPTION
Most of our projects use `as` syntax for type assertions.