### PR TITLE
Require space before asterisk in generator method definition

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -1301,22 +1301,30 @@ should be sticked to the `function` keyword:
   };
   ```
 
-* In a [shorthand method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)
-the asterisk should be sticked to the `method name`:
+* In a [method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)
+the asterisk should not be sticked to the `method name` or `modifier`:
+
+  > Explanation: asterisk is not a part of the method name or modifier.
+  > See https://exploringjs.com/es6/ch_generators.html#sec_formating-generators
 
   **Good:**
 
   ```js
-  class Graph {
-      *edges() {}
+  class Class {
+      * method() {}
+
+      static * method() {}
   }
   ```
 
   **Bad:**
 
   ```js
-  class Graph {
-      * edges() {}
+  class Class {
+      *method() {}
+
+      static *method() {}
+      static* method() {}
   }
   ```
 

--- a/packages/eslint-config-loris/es6.js
+++ b/packages/eslint-config-loris/es6.js
@@ -29,6 +29,10 @@ module.exports = {
         'prefer-spread': 'error',
         'rest-spread-spacing': ['error', 'never'],
         'template-curly-spacing': ['error', 'never'],
-        'yield-star-spacing': ['error', 'after']
+        'yield-star-spacing': ['error', {
+            before: false,
+            after: true,
+            method: {before: true, after: true}
+        }]
     }
 };


### PR DESCRIPTION
Current rule is inconsistent, because in generator function declaration asterisk symbol is stuck to the `function` keyword.  

There is good explanation in the [exploringjs book](https://exploringjs.com/es6/ch_generators.html#sec_formating-generators).

This rule in other styleguides:

* [Google](https://google.github.io/styleguide/jsguide.html#features-functions-generators): the same
* [Airbnb](https://github.com/airbnb/javascript#generators--spacing): not specified.